### PR TITLE
Salesforce_parsing_fix

### DIFF
--- a/plugins/salesforce/alerta_salesforce.py
+++ b/plugins/salesforce/alerta_salesforce.py
@@ -82,7 +82,8 @@ def get_sf_env_credentials(customer, environment, cluster_name):
         LOG.debug(f'env_clusters are {env_clusters}')
         for cluster_id, cluster_info in env_clusters.items():
             if cluster_info['name'] == cluster_name:
-                env_id = cluster_info['sf_env_id']
+                if 'sf_env_id' in cluster_info.keys():
+                    env_id = cluster_info['sf_env_id']
                 if 'sf_env_username' in cluster_info.keys():
                     username = cluster_info['sf_username']
                 if 'sf_env_password' in cluster_info.keys():

--- a/plugins/salesforce/setup.py
+++ b/plugins/salesforce/setup.py
@@ -1,7 +1,7 @@
 
 from setuptools import setup, find_packages
 
-version = '1.3.0'
+version = '1.3.1'
 
 setup(
     name="alerta-salesforce",


### PR DESCRIPTION
Checks to be sure the sf_env_id field exists at the cluster level before trying to read it.